### PR TITLE
Change of treble value handling

### DIFF
--- a/src/VS1053Driver.cpp
+++ b/src/VS1053Driver.cpp
@@ -543,15 +543,16 @@ bool VS1053::loadDefaultVs1053Patches() {
     return false;
 }
 
-/// Provides the treble amplitude value
-uint8_t VS1053::treble() {
-    return equilizer.treble().amplitude;
+/// Provides the treble level value
+int8_t VS1053::treble() {
+    return equilizer.treble().level;
 }
 
-/// Sets the treble amplitude value (range 0 to 100)
-void VS1053::setTreble(uint8_t value){
-    if (value>100) value = 100;
-    equilizer.treble().amplitude = value;
+/// Sets the treble level value (range -50 to 50)
+void VS1053::setTreble(int8_t value){
+    if (value>50) value = 50;
+    if (value<-50) value = -50;
+    equilizer.treble().level = value;
     writeRegister(SCI_BASS, equilizer.value());
 }
 

--- a/src/VS1053Driver.h
+++ b/src/VS1053Driver.h
@@ -115,7 +115,7 @@ class VS1053 {
             return result;
         }
         /// Register value for level
-        uint16_t scaledLevel(){
+        int16_t scaledLevel(){
             if (level>50) level = 50;
             if (level<50) level = -50;
             return static_cast<float>(amplitude)/100.0*15;

--- a/src/VS1053Driver.h
+++ b/src/VS1053Driver.h
@@ -366,11 +366,11 @@ class VS1053 {
     bool loadDefaultVs1053Patches();
 
 
-    /// Provides the treble amplitude value
-    uint8_t treble();
+    /// Provides the treble level value
+    int8_t treble();
 
-    /// Sets the treble amplitude value (range 0 to 100)
-    void setTreble(uint8_t value);
+    /// Sets the treble level value (range -50 0 to 50)
+    void setTreble(int8_t value);
 
     /// Provides the Bass amplitude value 
     uint8_t bass();

--- a/src/VS1053Driver.h
+++ b/src/VS1053Driver.h
@@ -118,7 +118,7 @@ class VS1053 {
         int16_t scaledLevel(){
             if (level>50) level = 50;
             if (level<50) level = -50;
-            return static_cast<float>(amplitude)/100.0*15;
+            return static_cast<float>(level)/100.0*15;
         }
     };
     /**

--- a/src/VS1053Driver.h
+++ b/src/VS1053Driver.h
@@ -101,6 +101,8 @@ class VS1053 {
         uint16_t freq_limit=0; 
         /// Amplitude value: range 0 to 100 
         uint8_t amplitude=0;  
+        /// Level value: range -50 to 50 
+        int8_t level=0;  
         /// Register value for amplitude
         uint16_t scaledAmplitude(){
             if (amplitude>100) amplitude = 100;
@@ -111,6 +113,12 @@ class VS1053 {
             uint16_t result = static_cast<float>(freq_limit) / scale;
             if (result>15) result = 15;
             return result;
+        }
+        /// Register value for level
+        uint16_t scaledLevel(){
+            if (level>50) level = 50;
+            if (level<50) level = -50;
+            return static_cast<float>(amplitude)/100.0*15;
         }
     };
     /**
@@ -136,7 +144,7 @@ class VS1053 {
         /// Provides the VS1053 SCI_BASS Register Value
         uint16_t value() {
             uint16_t result=0;
-            result |= v_treble.scaledAmplitude() << 12;
+            result |= v_treble.scaledLevel() << 12;
             result |= v_treble.scaledFreq(1000) << 8;
             result |= v_bass.scaledAmplitude() << 4;
             result |= v_bass.scaledFreq(10);


### PR DESCRIPTION
The treble value was treated as unsigned, changed to signed. The range in de SCI_BASS for treble is actually a signed nibble.
To set the treble value, now use -0.5 to 0.5 for less or more treble.